### PR TITLE
Relative Path Fix

### DIFF
--- a/index.php
+++ b/index.php
@@ -97,12 +97,17 @@ if(isset($_GET["clearcache"]) && $use_cache){
 		<script type="text/javascript">
 			var baseUrl = "<?php echo $_base_url; ?>";
 			var siteName = 'The Dojo Toolkit';
-			require([
+			require({
+				packages: [{
+					name: "api",
+					location: location.pathname.replace(/\/[^/]+$/, '') + "./js"
+				}]},
+			[
 				"dojo/dom",
 				"dojo/_base/fx",
 				"dojo/ready",
 				"dijit/registry",
-				"./js/api"		// main work is done in here
+				"api/api"		// main work is done in here
 			], function(dom, fx, ready, registry){
 				ready(function(){
 <?php if($is_page){ ?>

--- a/js/api.js
+++ b/js/api.js
@@ -4,8 +4,8 @@ require([
 	"dojo/parser",
 	"dijit/registry",
 	"dojox/fx/_core",
-	"./js/ModuleTreeModel",
-	"./js/ModuleTree",
+	"api/ModuleTreeModel",
+	"api/ModuleTree",
 
 	// Modules used by the parser
 	"dijit/layout/BorderContainer",


### PR DESCRIPTION
When trying to get the permalinks to work, and enabling Apache to read the `.htaccess`, it exposed the fact that the code uses relative paths for `require()`.  If you do this, the loader will not append `.js` and if the webserver does not map the URI to the `.js` extension, the application will not work.  (Apache does this by default on a Mac, but when you properly enable `AllowOverride All` it reads the `.htaccess` files disables this and the viewer stops working).

The "api" code needs to be properly packaged (e.g. with a package.json and a api.profile.js), but for now, this pull maps it to a local package and removes the relative URIs.
